### PR TITLE
Update compile script as scala is not required, only sbt

### DIFF
--- a/compile
+++ b/compile
@@ -15,10 +15,6 @@ if [[ $(which java) == "" ]]; then
 	print_need_tool "java"
 fi
 
-if [[ $(which scala) == "" ]]; then
-	print_need_tool "scala"
-fi
-
 if [[ $(which sbt) == "" ]]; then
 	print_need_tool "sbt"
 fi


### PR DESCRIPTION
I have no prior experience with Scala, so I just installed `sbt` as it is suggested on the Scala website. When I tried to compile Repetita, I still got the error about not having `scala` installed. I noticed that there is no other reference to `scala` within the `compile` script and that only `sbt` is used for compiling the Scala code.

If `scala` is actually required for something else, it might be good to make a direct point on the main `README` file.