### PR TITLE
Update the compile file to check and copy the appropriate gurobi.jar

### DIFF
--- a/compile
+++ b/compile
@@ -19,6 +19,14 @@ if [[ $(which sbt) == "" ]]; then
 	print_need_tool "sbt"
 fi
 
+# check for gurobi.jar and copy it under lib/                                   
+if [ -e "${GUROBI_HOME%%:*}/lib/gurobi.jar" ]; then                             
+  echo -e "Copying gurobi.jar from ${GUROBI_HOME%%:*}/lib"                         
+  cp ${GUROBI_HOME%%:*}/lib/gurobi.jar lib/                                     
+else                                                                            
+  echo -e "${RED}Could not find gurobi.jar in directory ${NC} ${GUROBI_HOME%%:*}/lib"          
+fi
+
 # check for gurobi
 if [[ ! -f lib/gurobi.jar ]]; then
 	echo -e "${RED}Please copy gurobi.jar in the lib/ directory.${NC}"


### PR DESCRIPTION
Having multiple versions of gurobi might result in run-time linking errors. The updated `compile` file will check and fetch the appropriate `gurobi.jar` file before compiling.