### PR TITLE
Add extra options specific to a solver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ lazy val root = (project in file(".")).
     libraryDependencies += "net.sf.jung" % "jung-visualization" % "2.1.1",
     libraryDependencies += "net.sf.jung" % "jung-graph-impl" % "2.1.1",
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.4",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.9.8",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.8",
     javaOptions in run += "-Xmx4G"    
   )
 

--- a/src/main/java/edu/repetita/core/Setting.java
+++ b/src/main/java/edu/repetita/core/Setting.java
@@ -1,8 +1,7 @@
 package edu.repetita.core;
 
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import edu.repetita.io.RepetitaParser;
 import edu.repetita.paths.ExplicitPaths;
@@ -42,7 +41,7 @@ public class Setting {
 	public String getTopologyFilename() {
 		return this.topologyFilename;
 	}
-	
+
 	public Topology getTopology() {
 		return this.topology;
 	}
@@ -50,11 +49,11 @@ public class Setting {
     public void setTopology(Topology topology) {
         this.topology = topology;
     }
-	
+
 	public String getDemandsFilename() {
 		return this.demandsFilename;
 	}
-	
+
 	public Demands getDemands() { return this.demands; }
 
     public void setDemands(Demands newDemands) {
@@ -113,13 +112,33 @@ public class Setting {
         return this.config.getExplicitPaths();
     }
 
+    /**
+     * Fills the args map with each extra argument name as key and its description as value
+     */
+    public void help(HashMap<String, String> args) { }
+
+    protected void setExtra(String key, Object value) throws IllegalArgumentException {
+        throw new IllegalArgumentException("This solver does not take option '" + key + "'");
+    }
+
+    public void setExtras(Map<String, Object> extras) throws IllegalArgumentException {
+        for (String key : extras.keySet()) {
+	        Object value = extras.get(key);
+            setExtra(key, value);
+        }
+    }
+
     public Setting clone(){
         Setting copy = new Setting();
+        this.init(copy);
+        return copy;
+    }
+
+    protected void init(Setting copy) {
         copy.setTopology(this.topology.clone());
         copy.setDemands(this.demands);
         copy.setDemandChanges(this.demandChanges);
         copy.setNumberReoptimizations(this.numberReoptimizations);
         copy.setRoutingConfiguration(this.getRoutingConfiguration().clone());
-        return copy;
     }
 }

--- a/src/main/java/edu/repetita/core/Solver.java
+++ b/src/main/java/edu/repetita/core/Solver.java
@@ -52,4 +52,11 @@ public abstract class Solver {
 	 * @return the time needed by the last call to solve(), in nanoseconds 
 	 */
 	public abstract long solveTime(Setting setting);
+
+	/**
+	 * @return a Setting object to store and parse all the specific arguments of this solver
+	 */
+	public Setting getSetting() {
+        return new Setting();
+    }
 }

--- a/src/main/java/edu/repetita/main/RepetitaStorage.java
+++ b/src/main/java/edu/repetita/main/RepetitaStorage.java
@@ -56,16 +56,18 @@ public class RepetitaStorage {
         return scenario;
     }
 
-    public Setting newSetting(String graphFilename, String demandsFilename){
-        Setting setting = new Setting();
+    public Setting newSetting(Solver solver, String graphFilename, String demandsFilename){
+        Setting setting = solver.getSetting();
         setting.setTopologyFilename(graphFilename);
         setting.setDemandsFilename(demandsFilename);
         return setting;
     }
 
-    public Setting newSetting(String graphFilename, String demandsFilename, List<String> otherDemandsFilenames){
-        Setting setting = this.newSetting(graphFilename,demandsFilename);
+    public Setting newSetting(Solver solver, String graphFilename, String demandsFilename,
+                              List<String> otherDemandsFilenames, Map<String, Object> extras){
+        Setting setting = this.newSetting(solver, graphFilename,demandsFilename);
         setting.setDemandChangesFilenames(otherDemandsFilenames);
+        setting.setExtras(extras);
         return setting;
     }
 

--- a/src/main/java/edu/repetita/scenarios/DemandChangeReoptimization.java
+++ b/src/main/java/edu/repetita/scenarios/DemandChangeReoptimization.java
@@ -37,7 +37,7 @@ public class DemandChangeReoptimization extends Scenario {
 
             // create a new (minimalistic) setting and analyze it
             Long timeBeforeChange = System.nanoTime();
-            Setting currentSetting = new Setting();
+            Setting currentSetting = this.setting.clone();
             currentSetting.setTopology(topology);
             currentSetting.setDemands(currentDemands);
             currentSetting.setRoutingConfiguration(lastConfig);

--- a/src/main/java/edu/repetita/settings/SRSetting.java
+++ b/src/main/java/edu/repetita/settings/SRSetting.java
@@ -1,0 +1,55 @@
+package edu.repetita.settings;
+
+import edu.repetita.core.Setting;
+
+import java.util.*;
+
+public class SRSetting extends Setting {
+
+	private int maxSeg = 1;
+
+	public int getMaxSeg() {
+		return maxSeg;
+	}
+
+	public void setMaxSeg(int maxSeg) {
+		this.maxSeg = maxSeg;
+	}
+
+	@Override
+	public void help(HashMap<String, String> args) {
+		args.put("maxseg", "The maximum number of intermediate segments (i.e., source and destination nodes are not counted)");
+	}
+
+	@Override
+	protected void setExtra(String key, Object value) throws IllegalArgumentException {
+		switch (key) {
+		case "maxseg":
+			if (!(value instanceof Integer)) {
+				throw new IllegalArgumentException("The maximum number of intermediate segments should be an integer.");
+			}
+			int maxSeg = (Integer) value;
+			if (maxSeg < 0) {
+				throw new IllegalArgumentException("'" + value + "' is not a valid number of segment." +
+						" It should be positive.");
+			}
+			this.maxSeg = maxSeg;
+			break;
+		default:
+			super.setExtra(key, value);
+		}
+	}
+
+	@Override
+	public Setting clone() {
+		Setting copy = new SRSetting();
+		this.init(copy);
+		return copy;
+	}
+
+	@Override
+	protected void init(Setting copy) {
+		super.init(copy);
+		((SRSetting) copy).setMaxSeg(maxSeg);
+	}
+}

--- a/src/main/java/edu/repetita/solvers/SRSolver.java
+++ b/src/main/java/edu/repetita/solvers/SRSolver.java
@@ -1,6 +1,8 @@
 package edu.repetita.solvers;
 
+import edu.repetita.core.Setting;
 import edu.repetita.core.Solver;
+import edu.repetita.settings.SRSetting;
 
 /**
  * Abstract class implementing methods common to all segment-routing based solvers.
@@ -12,4 +14,9 @@ public abstract class SRSolver extends Solver {
     public double getTargetObjectiveValue() { return this.targetObjectiveValue; }
 
     public void setTargetObjectiveValue(double value) { this.targetObjectiveValue = value; }
+
+    @Override
+    public Setting getSetting() {
+        return new SRSetting();
+    }
 }

--- a/src/main/java/edu/repetita/solvers/sr/DefoCP.java
+++ b/src/main/java/edu/repetita/solvers/sr/DefoCP.java
@@ -9,6 +9,7 @@ import edu.repetita.core.Demands;
 import edu.repetita.core.Setting;
 import edu.repetita.core.Topology;
 import edu.repetita.paths.SRPaths;
+import edu.repetita.settings.SRSetting;
 import edu.repetita.solvers.SRSolver;
 
 import java.io.PrintWriter;
@@ -41,10 +42,11 @@ public class DefoCP extends SRSolver {
 
     @Override
     public void solve(Setting setting, long timeMillis) {
+        SRSetting srSetting = (SRSetting) setting;
         // extract information from setting
-        Topology topology = setting.getTopology();
+        Topology topology = srSetting.getTopology();
         int nEdges = topology.nEdges;
-        Demands demands = setting.getDemands();
+        Demands demands = srSetting.getDemands();
 
         // translate in scala data structures
         be.ac.ucl.ingi.defo.core.Topology defoTopology = be.ac.ucl.ingi.defo.core.Topology.apply(topology.edgeSrc, topology.edgeDest);
@@ -57,7 +59,7 @@ public class DefoCP extends SRSolver {
         DEFOConstraint[][] demandConstraints = new DEFOConstraint[demands.nDemands][0];
         DEFOConstraint[] topologyConstraints = new DEFOConstraint[0];
 
-        DEFOInstance instance = new DEFOInstance(defoTopology, topology.edgeWeight, demandTraffic, demands.source, demands.dest, demandConstraints, topologyConstraints, edgeCapacities, topology.edgeLatency);
+        DEFOInstance instance = new DEFOInstance(defoTopology, topology.edgeWeight, demandTraffic, demands.source, demands.dest, demandConstraints, topologyConstraints, edgeCapacities, topology.edgeLatency, srSetting.getMaxSeg());
         DEFOptimizer optimizer = new DEFOptimizer(instance, this.verbose > 0, scala.Option.apply((PrintWriter) null));
 
         TimeUnit timeLimit = new TimeUnit((int) timeMillis, timeMillis + "ms");
@@ -72,11 +74,11 @@ public class DefoCP extends SRSolver {
 
         // write results back
         int[][] bestPaths = optimizer.core().bestPaths();
-        SRPaths paths = new SRPaths(setting.getDemands(),setting.getTopology().nNodes);
+        SRPaths paths = new SRPaths(srSetting.getDemands(),srSetting.getTopology().nNodes);
         for (int demand = 0; demand < demands.nDemands; demand++) {
             paths.setPath(demand, bestPaths[demand]);
         }
-        setting.setSRPaths(paths);
+        srSetting.setSRPaths(paths);
     }
 
 }

--- a/src/main/java/edu/repetita/solvers/sr/MIPTwoSRNoSplit.java
+++ b/src/main/java/edu/repetita/solvers/sr/MIPTwoSRNoSplit.java
@@ -278,4 +278,9 @@ public class MIPTwoSRNoSplit extends SRSolver {
         }
     }
 
+    @Override
+    public Setting getSetting() {
+        return new Setting();
+    }
+
 }

--- a/src/main/java/edu/repetita/solvers/sr/SRLS.java
+++ b/src/main/java/edu/repetita/solvers/sr/SRLS.java
@@ -4,6 +4,7 @@ import edu.repetita.core.Demands;
 import edu.repetita.core.Setting;
 import edu.repetita.core.Topology;
 import edu.repetita.paths.SRPaths;
+import edu.repetita.settings.SRSetting;
 import edu.repetita.solvers.SRSolver;
 import be.ac.ucl.ingi.rls.LoadOptimizer;
 import be.ac.ucl.ingi.rls.io.DemandsData;
@@ -71,6 +72,7 @@ public class SRLS extends SRSolver {
     private void initializeScalaVariables(Setting setting){
         Topology topology = setting.getTopology();
         Demands demands = setting.getDemands();
+        SRSetting srSetting = (SRSetting) setting;
 
         rlsTopology = TopologyData.apply(
                 topology.nodeLabel,
@@ -83,6 +85,6 @@ public class SRLS extends SRSolver {
         );
 
         rlsDemands = DemandsData.apply(demands.label, demands.source, demands.dest, demands.amount);
-        loadOptimizer = new LoadOptimizer(rlsTopology, rlsDemands, this.verbose > 0);
+        loadOptimizer = new LoadOptimizer(rlsTopology, rlsDemands, srSetting.getMaxSeg(), this.verbose > 0);
     }
 }

--- a/src/main/scala/be/ac/ucl/ingi/defo/core/CoreSolver.scala
+++ b/src/main/scala/be/ac/ucl/ingi/defo/core/CoreSolver.scala
@@ -41,6 +41,7 @@ class CoreSolver(instance: DEFOInstance, verbose: Boolean, statsFile: Option[Pri
   private[this] val latencies: Array[Int] = instance.latencies
   private[this] val nEdges = topology.nEdges
   private[this] val nNodes = topology.nNodes
+  private[this] val maxSeg = instance.maxSeg // Max number of intermediate segments (i.e., source and destination node not included)
 
   // Preprocessed data
   private[this] val ecmpStruct = ECMPStructure(topology, weights, latencies)
@@ -250,7 +251,7 @@ class CoreSolver(instance: DEFOInstance, verbose: Boolean, statsFile: Option[Pri
         val demand = demandsId(i)
 
         // Path length
-        constraints.append(paths(i).length <= 4)
+        constraints.append(paths(i).length <= 2 + maxSeg)
         // Reach
         constraints.append(new CanReach(paths(i), reachStruct))
         // The graph of links is acyclic

--- a/src/main/scala/be/ac/ucl/ingi/defo/core/DEFOInstance.scala
+++ b/src/main/scala/be/ac/ucl/ingi/defo/core/DEFOInstance.scala
@@ -13,10 +13,11 @@ class DEFOInstance(
   val demandConstraints: Array[Array[DEFOConstraint]],
   val topologyConstraints: Array[DEFOConstraint],
   val capacities: Array[Int],
-  val latencies: Array[Int])
+  val latencies: Array[Int],
+  val maxSeg: Int = 2)
   
 object DEFOInstance {
-  def apply(topologyData: TopologyData, demandsData: DemandsData): DEFOInstance = {
+  def apply(topologyData: TopologyData, demandsData: DemandsData, maxSeg: Int): DEFOInstance = {
     val topology = Topology(topologyData.edgeSrcs, topologyData.edgeDests)
     new DEFOInstance(
       topology,
@@ -27,7 +28,8 @@ object DEFOInstance {
       Array.fill(demandsData.demandTraffics.length)(Array.empty),
       Array.empty,
       topologyData.edgeCapacities,
-      topologyData.edgeLatencies
+      topologyData.edgeLatencies,
+      maxSeg
     )
   }
 }

--- a/src/main/scala/be/ac/ucl/ingi/rls/LoadOptimizer.scala
+++ b/src/main/scala/be/ac/ucl/ingi/rls/LoadOptimizer.scala
@@ -19,7 +19,7 @@ import be.ac.ucl.ingi.rls.metaheuristic.WeightedDemands
  *  LoadOptimizer tries to find paths so that the max maxLinkLoad of edges is minimal.
  */
 
-class LoadOptimizer(topologyData: TopologyData, decisionDemands: DemandsData)(debug: Boolean) {
+class LoadOptimizer(topologyData: TopologyData, decisionDemands: DemandsData, maxSeg: Int)(debug: Boolean) {
   private val topology = Topology(topologyData)
   
   /*
@@ -53,7 +53,7 @@ class LoadOptimizer(topologyData: TopologyData, decisionDemands: DemandsData)(de
   // val delays = new DelayDataImpl(topology.nNodes, shortestPaths, topologyData)
   
   // initialize network state
-  private val pathState  = new PathState(decisionDemands)
+  private val pathState  = new PathState(decisionDemands, maxSeg)
   // val delayState = new DelayState(nDemands, delays, pathState)
   
 //  val flowState  = new FlowStateRecomputeDAG(nNodes, nEdges, shortestPaths, pathState, decisionDemands)

--- a/src/main/scala/be/ac/ucl/ingi/rls/state/PathState.scala
+++ b/src/main/scala/be/ac/ucl/ingi/rls/state/PathState.scala
@@ -8,11 +8,11 @@ import be.ac.ucl.ingi.rls.io.DemandsData
  *  A structure to store the current paths (detour sequences) in the network.
  */ 
 
-class PathState(demands: DemandsData)
+class PathState(demands: DemandsData, maxSeg: Int)
 extends TrialState
 {
   val nDemands = demands.nDemands
-  val maxDetourSize = 6
+  val maxDetourSize = 2 + maxSeg
   
   def source(demand: Demand): Node = demands.demandSrcs(demand)
   def destination(demand: Demand): Node = demands.demandDests(demand)


### PR DESCRIPTION
This PR adds an extra option to Repetita: '--extra <filepath>'
This gives the path to a JSON file containing a dictionary.
This dictionary sets values for some options that are specific to a
particular solver.

For instance, one extra option is introduced for defoCP and SRLS.
This argument controls the maximum number of intermediate segments
that these solvers can use.

This fixes issue #7 